### PR TITLE
Set the correct input encoding

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -340,7 +340,7 @@ setup(
     author='Kevin Sheppard',
     author_email='kevin.k.sheppard@gmail.com',
     distclass=BinaryDistribution,
-    long_description=open('README.rst').read(),
+    long_description=open('README.rst', encoding="utf-8").read(),
     description='Random generator supporting multiple PRNGs',
     url='https://github.com/bashtage/randomgen',
     keywords=['pseudo random numbers', 'PRNG', 'RNG', 'RandomState', 'random',


### PR DESCRIPTION
Currently `setup.py` assumes the default encoding is `utf-8`. In fact, this is system dependent and will cause randomgen to fail to build on a system which has the wrong default encoding (I discovered this when trying to build randomgen in a docker container which for some reason had a default encoding of `ANSI_X3.4-1968`.

This one-line patch explicitly sets the encoding when reading `README.rst` to  `utf-8`.