### PR TITLE
ENH: Use a consistent dtype for randint

### DIFF
--- a/randomgen/generator.pyx
+++ b/randomgen/generator.pyx
@@ -430,26 +430,11 @@ cdef class RandomGenerator:
                 [ True,  True]]])
 
         """
-        cdef np.npy_intp n
-        cdef np.ndarray randoms
-        cdef int64_t *randoms_data
+        return self.randint(0, np.iinfo(np.int).max + 1, dtype=np.int, size=size)
 
-        if size is None:
-            with self.lock:
-                return random_positive_int(self._brng)
-
-        randoms = <np.ndarray>np.empty(size, dtype=np.int64)
-        randoms_data = <int64_t*>np.PyArray_DATA(randoms)
-        n = np.PyArray_SIZE(randoms)
-
-        for i in range(n):
-            with self.lock, nogil:
-                randoms_data[i] = random_positive_int(self._brng)
-        return randoms
-
-    def randint(self, low, high=None, size=None, dtype=int, use_masked=True):
+    def randint(self, low, high=None, size=None, dtype=np.int64, use_masked=True):
         """
-        randint(low, high=None, size=None, dtype='l', use_masked=True)
+        randint(low, high=None, size=None, dtype='int64', use_masked=True)
 
         Return random integers from `low` (inclusive) to `high` (exclusive).
 

--- a/randomgen/tests/test_against_numpy.py
+++ b/randomgen/tests/test_against_numpy.py
@@ -184,6 +184,7 @@ class TestAgainstNumPy(object):
                         self.rs.standard_exponential)
         self._is_state_common_legacy()
 
+    @pytest.mark.xfail(reason='Stream broken for simplicity')
     def test_tomaxint(self):
         self._set_common_state()
         self._is_state_common()


### PR DESCRIPTION
Use a consistent int64 style for randint accross platforms