### PR TITLE
ENH: Add closed interval sampling to randint

### DIFF
--- a/doc/source/change-log.rst
+++ b/doc/source/change-log.rst
@@ -1,6 +1,14 @@
 Change Log
 ----------
 
+Since v1.16.4
+=============
+- Added keyword ``closed`` to :func:`~randomgen.generator.RandomGenerator.randint`
+  which changes sampling from the half-open interval ``[low, high)`` to the closed
+  interval ``[low, high]``.
+- Fixed a bug in :func:`~randomgen.mtrand.RandomState.random_integers` that
+  could lead to valid values being treated as invalid.
+
 v1.16.4
 =======
 - Add a fast path for broadcasting :func:`~randomgen.generator.RandomGenerator.randint`

--- a/randomgen/bounded_integers.pxd.in
+++ b/randomgen/bounded_integers.pxd.in
@@ -22,5 +22,5 @@ py:
 inttypes = ('uint64','uint32','uint16','uint8','bool','int64','int32','int16','int8')
 }}
 {{for inttype in inttypes}}
-cdef object _rand_{{inttype}}(object low, object high, object size, bint use_masked, brng_t *state, object lock)
+cdef object _rand_{{inttype}}(object low, object high, object size, bint use_masked, bint closed, brng_t *state, object lock)
 {{endfor}}

--- a/randomgen/bounded_integers.pyx.in
+++ b/randomgen/bounded_integers.pyx.in
@@ -30,7 +30,7 @@ type_info = (('uint32', 'uint32', 'uint64', 'NPY_UINT64', 0, 0, 0, '0X100000000U
 {{for  nptype, utype, nptype_up, npctype, remaining, bitshift, lb, ub in type_info}}
 {{ py: otype = nptype + '_' if nptype == 'bool' else nptype }}
 cdef object _rand_{{nptype}}_broadcast(np.ndarray low, np.ndarray high, object size,
-                                       bint use_masked,
+                                       bint use_masked, bint closed,
                                        brng_t *state, object lock):
     """
     Array path for smaller integer types
@@ -40,7 +40,7 @@ cdef object _rand_{{nptype}}_broadcast(np.ndarray low, np.ndarray high, object s
     this type for checking and the recast to {{nptype}} when producing the
     random integers.
     """
-    cdef {{utype}}_t rng, last_rng, off, val, mask, out_val
+    cdef {{utype}}_t rng, last_rng, off, val, mask, out_val, is_open
     cdef uint32_t buf
     cdef {{utype}}_t *out_data
     cdef {{nptype_up}}_t low_v, high_v
@@ -50,13 +50,21 @@ cdef object _rand_{{nptype}}_broadcast(np.ndarray low, np.ndarray high, object s
     cdef int buf_rem = 0
 
     # Array path
+    is_open = not closed
     low_arr = <np.ndarray>low
     high_arr = <np.ndarray>high
     if np.any(np.less(low_arr, {{lb}})):
         raise ValueError('low is out of bounds for {{nptype}}')
-    if np.any(np.greater(high_arr, {{ub}})):
+    if closed:
+        high_comp = np.greater_equal
+        low_high_comp = np.greater
+    else:
+        high_comp = np.greater
+        low_high_comp = np.greater_equal
+
+    if np.any(high_comp(high_arr, {{ub}})):
         raise ValueError('high is out of bounds for {{nptype}}')
-    if np.any(np.greater_equal(low_arr, high_arr)):
+    if np.any(low_high_comp(low_arr, high_arr)):
         raise ValueError('low >= high')
 
     low_arr = <np.ndarray>np.PyArray_FROM_OTF(low, np.{{npctype}}, np.NPY_ALIGNED | np.NPY_FORCECAST)
@@ -77,7 +85,7 @@ cdef object _rand_{{nptype}}_broadcast(np.ndarray low, np.ndarray high, object s
             low_v = (<{{nptype_up}}_t*>np.PyArray_MultiIter_DATA(it, 0))[0]
             high_v = (<{{nptype_up}}_t*>np.PyArray_MultiIter_DATA(it, 1))[0]
             # Subtract 1 since generator produces values on the closed int [off, off+rng]
-            rng = <{{utype}}_t>((high_v - 1) - low_v)
+            rng = <{{utype}}_t>((high_v - is_open) - low_v)
             off = <{{utype}}_t>(<{{nptype_up}}_t>low_v)
 
             if rng != last_rng:
@@ -97,7 +105,7 @@ big_type_info = (('uint64', 'uint64', 'NPY_UINT64', '0x0ULL', '0xFFFFFFFFFFFFFFF
 {{for  nptype, utype, npctype, lb, ub in big_type_info}}
 {{ py: otype = nptype}}
 cdef object _rand_{{nptype}}_broadcast(object low, object high, object size,
-                                       bint use_masked,
+                                       bint use_masked, bint closed,
                                        brng_t *state, object lock):
     """
     Array path for 64-bit integer types
@@ -126,11 +134,12 @@ cdef object _rand_{{nptype}}_broadcast(object low, object high, object size,
     if np.any(np.less(low_arr, {{lb}})):
         raise ValueError('low is out of bounds for {{nptype}}')
     dt = high_arr.dtype
-    if np.issubdtype(dt, np.integer):
+    if closed or np.issubdtype(dt, np.integer):
         # Avoid object dtype path if already an integer
-        if np.any(np.less_equal(high_arr, {{lb}})):
+        high_lower_comp = np.less if closed else np.less_equal
+        if np.any(high_lower_comp(high_arr, {{lb}})):
             raise ValueError('low >= high')
-        high_m1 = high_arr - dt.type(1)
+        high_m1 = high_arr if closed else high_arr - dt.type(1)
         if np.any(np.greater(high_m1, {{ub}})):
             raise ValueError('high is out of bounds for {{nptype}}')
         highm1_arr = <np.ndarray>np.PyArray_FROM_OTF(high_m1, np.{{npctype}}, np.NPY_ALIGNED | np.NPY_FORCECAST)
@@ -196,7 +205,7 @@ type_info = (('uint64', 'uint64', '0x0ULL', '0xFFFFFFFFFFFFFFFFULL'),
 {{for  nptype, utype, lb, ub in type_info}}
 {{ py: otype = nptype + '_' if nptype == 'bool' else nptype }}
 cdef object _rand_{{nptype}}(object low, object high, object size,
-                             bint use_masked,
+                             bint use_masked, bint closed,
                              brng_t *state, object lock):
     """
     _rand_{{nptype}}(low, high, size, use_masked, *state, lock)
@@ -223,6 +232,8 @@ cdef object _rand_{{nptype}}(object low, object high, object size,
         single value is returned.
     use_masked : bool
         If True then rejection sampling with a range mask is used else Lemire's algorithm is used.
+    closed : bool
+        If True then sample from [low, high].  If False, sample [low, high)
     state : basic random state
         State to use in the core random number generators
     lock : threading.Lock
@@ -237,10 +248,10 @@ cdef object _rand_{{nptype}}(object low, object high, object size,
     Notes
     -----
     The internal integer generator produces values from the closed
-    interval [low, high-1].  This requires some care since high can be
-    out-of-range for {{utype}}. The scalar path leaves integers as Python
-    integers until the 1 has been subtracted to avoid needing to cast
-    to a larger type.
+    interval [low, high-(not closed)].  This requires some care since 
+    high can be out-of-range for {{utype}}. The scalar path leaves 
+    integers as Python integers until the 1 has been subtracted to 
+    avoid needing to cast to a larger type.
     """
     cdef np.ndarray out_arr, low_arr, high_arr
     cdef {{utype}}_t rng, off, out_val
@@ -260,7 +271,8 @@ cdef object _rand_{{nptype}}(object low, object high, object size,
         low = int(low_arr)
         high = int(high_arr)
         # Subtract 1 since internal generator produces on closed interval [low, high]
-        high -= 1
+        if not closed:
+            high -= 1
 
         if low < {{lb}}:
             raise ValueError("low is out of bounds for {{nptype}}")
@@ -282,5 +294,5 @@ cdef object _rand_{{nptype}}(object low, object high, object size,
             with lock, nogil:
                 random_bounded_{{utype}}_fill(state, off, rng, cnt, use_masked, out_data)
             return out_arr
-    return _rand_{{nptype}}_broadcast(low_arr, high_arr, size, use_masked, state, lock)
+    return _rand_{{nptype}}_broadcast(low_arr, high_arr, size, use_masked, closed, state, lock)
 {{endfor}}

--- a/randomgen/generator.pyx
+++ b/randomgen/generator.pyx
@@ -421,9 +421,10 @@ cdef class RandomGenerator:
 
         See Also
         --------
-        randint : Uniform sampling over a given half-open interval of integers.
+        randint : Uniform sampling over a given half-open or closed interval
+                  of integers.
         random_integers : Uniform sampling over a given closed interval of
-            integers.
+                          integers.
 
         Examples
         --------
@@ -442,15 +443,19 @@ cdef class RandomGenerator:
         """
         return self.randint(0, np.iinfo(np.int).max + 1, dtype=np.int, size=size)
 
-    def randint(self, low, high=None, size=None, dtype=np.int64, use_masked=True):
+    def randint(self, low, high=None, size=None, dtype=np.int64, use_masked=True,
+                closed=False):
         """
-        randint(low, high=None, size=None, dtype='int64', use_masked=True)
+        randint(low, high=None, size=None, dtype='int64', use_masked=True, closed=False)
 
-        Return random integers from `low` (inclusive) to `high` (exclusive).
+        Return random integers from `low` (inclusive) to `high` (exclusive), or
+        if closed=True, `low` (inclusive) to `high` (inclusive).
 
         Return random integers from the "discrete uniform" distribution of
         the specified dtype in the "half-open" interval [`low`, `high`). If
-        `high` is None (the default), then results are from [0, `low`).
+        `high` is None (the default), then results are from [0, `low`). If
+        `closed` is True, then samples from the closed interval [`low`, `high`]
+        or [0, `low`] if `high` is None.
 
         Parameters
         ----------
@@ -476,10 +481,14 @@ cdef class RandomGenerator:
 
         use_masked : bool
             If True the generator uses rejection sampling with a bit mask to
-            reject random numbers that are out of bounds. If False the generator
-            will use Lemire's rejection sampling algorithm.
+            reject random numbers that are out of bounds. If False the
+            generator will use Lemire's rejection sampling algorithm.
 
             .. versionadded:: 1.15.1
+
+        closed : bool
+            If true, sample from the interval [low, high] instead of the
+            default [low, high)
 
         Returns
         -------
@@ -544,23 +553,23 @@ cdef class RandomGenerator:
             raise TypeError('Unsupported dtype "%s" for randint' % key)
 
         if key == 'int32':
-            ret = _rand_int32(low, high, size, use_masked, self._brng, self.lock)
+            ret = _rand_int32(low, high, size, use_masked, closed, self._brng, self.lock)
         elif key == 'int64':
-            ret = _rand_int64(low, high, size, use_masked, self._brng, self.lock)
+            ret = _rand_int64(low, high, size, use_masked, closed, self._brng, self.lock)
         elif key == 'int16':
-            ret = _rand_int16(low, high, size, use_masked, self._brng, self.lock)
+            ret = _rand_int16(low, high, size, use_masked, closed, self._brng, self.lock)
         elif key == 'int8':
-            ret = _rand_int8(low, high, size, use_masked, self._brng, self.lock)
+            ret = _rand_int8(low, high, size, use_masked, closed, self._brng, self.lock)
         elif key == 'uint64':
-            ret = _rand_uint64(low, high, size, use_masked, self._brng, self.lock)
+            ret = _rand_uint64(low, high, size, use_masked, closed, self._brng, self.lock)
         elif key == 'uint32':
-            ret = _rand_uint32(low, high, size, use_masked, self._brng, self.lock)
+            ret = _rand_uint32(low, high, size, use_masked, closed, self._brng, self.lock)
         elif key == 'uint16':
-            ret = _rand_uint16(low, high, size, use_masked, self._brng, self.lock)
+            ret = _rand_uint16(low, high, size, use_masked, closed, self._brng, self.lock)
         elif key == 'uint8':
-            ret = _rand_uint8(low, high, size, use_masked, self._brng, self.lock)
+            ret = _rand_uint8(low, high, size, use_masked, closed, self._brng, self.lock)
         elif key == 'bool':
-            ret = _rand_bool(low, high, size, use_masked, self._brng, self.lock)
+            ret = _rand_bool(low, high, size, use_masked, closed, self._brng, self.lock)
 
         if size is None and dtype in (np.bool, np.int, np.long):
             if np.array(ret).shape == ():

--- a/randomgen/mtrand.pyx
+++ b/randomgen/mtrand.pyx
@@ -591,23 +591,23 @@ cdef class RandomState:
             raise TypeError('Unsupported dtype "%s" for randint' % key)
 
         if key == 'int32':
-            ret = _rand_int32(low, high, size, use_masked, self._brng, self.lock)
+            ret = _rand_int32(low, high, size, use_masked, False, self._brng, self.lock)
         elif key == 'int64':
-            ret = _rand_int64(low, high, size, use_masked, self._brng, self.lock)
+            ret = _rand_int64(low, high, size, use_masked, False, self._brng, self.lock)
         elif key == 'int16':
-            ret = _rand_int16(low, high, size, use_masked, self._brng, self.lock)
+            ret = _rand_int16(low, high, size, use_masked, False, self._brng, self.lock)
         elif key == 'int8':
-            ret = _rand_int8(low, high, size, use_masked, self._brng, self.lock)
+            ret = _rand_int8(low, high, size, use_masked, False, self._brng, self.lock)
         elif key == 'uint64':
-            ret = _rand_uint64(low, high, size, use_masked, self._brng, self.lock)
+            ret = _rand_uint64(low, high, size, use_masked, False, self._brng, self.lock)
         elif key == 'uint32':
-            ret = _rand_uint32(low, high, size, use_masked, self._brng, self.lock)
+            ret = _rand_uint32(low, high, size, use_masked, False, self._brng, self.lock)
         elif key == 'uint16':
-            ret = _rand_uint16(low, high, size, use_masked, self._brng, self.lock)
+            ret = _rand_uint16(low, high, size, use_masked, False, self._brng, self.lock)
         elif key == 'uint8':
-            ret = _rand_uint8(low, high, size, use_masked, self._brng, self.lock)
+            ret = _rand_uint8(low, high, size, use_masked, False, self._brng, self.lock)
         elif key == 'bool':
-            ret = _rand_bool(low, high, size, use_masked, self._brng, self.lock)
+            ret = _rand_bool(low, high, size, use_masked, False, self._brng, self.lock)
 
         if size is None and dtype in (np.bool, np.int, np.long):
             if np.array(ret).shape == ():

--- a/randomgen/tests/test_generator_mt19937.py
+++ b/randomgen/tests/test_generator_mt19937.py
@@ -5,12 +5,18 @@ import numpy as np
 from numpy.testing import (assert_, assert_array_almost_equal,
                            assert_array_equal, assert_equal,
                            assert_no_warnings, assert_raises, assert_warns)
+import pytest
 
 from randomgen import MT19937, RandomGenerator
 from randomgen._testing import suppress_warnings
 from randomgen.tests.test_direct import assert_state_equal
 
 random = RandomGenerator(MT19937())
+
+
+@pytest.fixture(scope='module', params=[True, False])
+def closed(request):
+    return request.param
 
 
 class TestSeed(object):
@@ -145,57 +151,62 @@ class TestRandint(object):
     itype = [bool, np.int8, np.uint8, np.int16, np.uint16,
              np.int32, np.uint32, np.int64, np.uint64]
 
-    def test_unsupported_type(self):
-        assert_raises(TypeError, self.rfunc, 1, dtype=float)
+    def test_unsupported_type(self, closed):
+        assert_raises(TypeError, self.rfunc, 1, closed=closed, dtype=float)
 
-    def test_bounds_checking(self):
+    def test_bounds_checking(self, closed):
         for dt in self.itype:
             lbnd = 0 if dt is bool else np.iinfo(dt).min
             ubnd = 2 if dt is bool else np.iinfo(dt).max + 1
-            assert_raises(ValueError, self.rfunc, lbnd - 1, ubnd, dtype=dt)
-            assert_raises(ValueError, self.rfunc, lbnd, ubnd + 1, dtype=dt)
-            assert_raises(ValueError, self.rfunc, ubnd, lbnd, dtype=dt)
-            assert_raises(ValueError, self.rfunc, 1, 0, dtype=dt)
+            ubnd = ubnd - 1 if closed else ubnd
+            assert_raises(ValueError, self.rfunc, lbnd - 1, ubnd, closed=closed, dtype=dt)
+            assert_raises(ValueError, self.rfunc, lbnd, ubnd + 1, closed=closed, dtype=dt)
+            assert_raises(ValueError, self.rfunc, ubnd, lbnd, closed=closed, dtype=dt)
+            assert_raises(ValueError, self.rfunc, 1, 0, closed=closed, dtype=dt)
 
-            assert_raises(ValueError, self.rfunc, [lbnd - 1], ubnd, dtype=dt)
-            assert_raises(ValueError, self.rfunc, [lbnd], [ubnd + 1], dtype=dt)
-            assert_raises(ValueError, self.rfunc, [ubnd], [lbnd], dtype=dt)
-            assert_raises(ValueError, self.rfunc, 1, [0], dtype=dt)
+            assert_raises(ValueError, self.rfunc, [lbnd - 1], ubnd, closed=closed, dtype=dt)
+            assert_raises(ValueError, self.rfunc, [lbnd], [ubnd + 1], closed=closed, dtype=dt)
+            assert_raises(ValueError, self.rfunc, [ubnd], [lbnd], closed=closed, dtype=dt)
+            assert_raises(ValueError, self.rfunc, 1, [0], closed=closed, dtype=dt)
 
-    def test_bounds_checking_array(self):
+    def test_bounds_checking_array(self, closed):
         for dt in self.itype:
             lbnd = 0 if dt is bool else np.iinfo(dt).min
-            ubnd = 2 if dt is bool else np.iinfo(dt).max + 1
+            ubnd = 2 if dt is bool else np.iinfo(dt).max + (not closed)
+
             assert_raises(ValueError, self.rfunc, [
-                          lbnd - 1] * 2, [ubnd] * 2, dtype=dt)
+                          lbnd - 1] * 2, [ubnd] * 2, closed=closed, dtype=dt)
             assert_raises(ValueError, self.rfunc, [
-                          lbnd] * 2, [ubnd + 1] * 2, dtype=dt)
-            assert_raises(ValueError, self.rfunc, ubnd, [lbnd] * 2, dtype=dt)
-            assert_raises(ValueError, self.rfunc, [1] * 2, 0, dtype=dt)
+                          lbnd] * 2, [ubnd + 1] * 2, closed=closed, dtype=dt)
+            assert_raises(ValueError, self.rfunc, ubnd, [lbnd] * 2, closed=closed, dtype=dt)
+            assert_raises(ValueError, self.rfunc, [1] * 2, 0, closed=closed, dtype=dt)
 
-    def test_rng_zero_and_extremes(self):
+    def test_rng_zero_and_extremes(self, closed):
         for dt in self.itype:
             lbnd = 0 if dt is bool else np.iinfo(dt).min
             ubnd = 2 if dt is bool else np.iinfo(dt).max + 1
+            ubnd = ubnd - 1 if closed else ubnd
+            is_open = not closed
 
             tgt = ubnd - 1
-            assert_equal(self.rfunc(tgt, tgt + 1, size=1000, dtype=dt), tgt)
-            assert_equal(self.rfunc([tgt], tgt + 1, size=1000, dtype=dt), tgt)
+            assert_equal(self.rfunc(tgt, tgt + is_open, size=1000, closed=closed, dtype=dt), tgt)
+            assert_equal(self.rfunc([tgt], tgt + is_open, size=1000, closed=closed, dtype=dt), tgt)
 
             tgt = lbnd
-            assert_equal(self.rfunc(tgt, tgt + 1, size=1000, dtype=dt), tgt)
-            assert_equal(self.rfunc(tgt, [tgt + 1], size=1000, dtype=dt), tgt)
+            assert_equal(self.rfunc(tgt, tgt + is_open, size=1000, closed=closed, dtype=dt), tgt)
+            assert_equal(self.rfunc(tgt, [tgt + is_open], size=1000, closed=closed, dtype=dt), tgt)
 
             tgt = (lbnd + ubnd) // 2
-            assert_equal(self.rfunc(tgt, tgt + 1, size=1000, dtype=dt), tgt)
-            assert_equal(self.rfunc([tgt], [tgt + 1],
-                                    size=1000, dtype=dt), tgt)
+            assert_equal(self.rfunc(tgt, tgt + is_open, size=1000, closed=closed, dtype=dt), tgt)
+            assert_equal(self.rfunc([tgt], [tgt + is_open],
+                                    size=1000, closed=closed, dtype=dt), tgt)
 
-    def test_rng_zero_and_extremes_array(self):
+    def test_rng_zero_and_extremes_array(self, closed):
         size = 1000
         for dt in self.itype:
             lbnd = 0 if dt is bool else np.iinfo(dt).min
             ubnd = 2 if dt is bool else np.iinfo(dt).max + 1
+            ubnd = ubnd - 1 if closed else ubnd
 
             tgt = ubnd - 1
             assert_equal(self.rfunc([tgt], [tgt + 1],
@@ -221,68 +232,70 @@ class TestRandint(object):
             assert_equal(self.rfunc(
                 [tgt] * size, [tgt + 1] * size, size=size, dtype=dt), tgt)
 
-    def test_full_range(self):
+    def test_full_range(self, closed):
         # Test for ticket #1690
 
         for dt in self.itype:
             lbnd = 0 if dt is bool else np.iinfo(dt).min
             ubnd = 2 if dt is bool else np.iinfo(dt).max + 1
+            ubnd = ubnd - 1 if closed else ubnd
 
             try:
-                self.rfunc(lbnd, ubnd, dtype=dt)
+                self.rfunc(lbnd, ubnd, closed=closed, dtype=dt)
             except Exception as e:
                 raise AssertionError("No error should have been raised, "
                                      "but one was with the following "
                                      "message:\n\n%s" % str(e))
 
-    def test_full_range_array(self):
+    def test_full_range_array(self, closed):
         # Test for ticket #1690
 
         for dt in self.itype:
             lbnd = 0 if dt is bool else np.iinfo(dt).min
             ubnd = 2 if dt is bool else np.iinfo(dt).max + 1
+            ubnd = ubnd - 1 if closed else ubnd
 
             try:
-                self.rfunc([lbnd] * 2, [ubnd], dtype=dt)
+                self.rfunc([lbnd] * 2, [ubnd], closed=closed, dtype=dt)
             except Exception as e:
                 raise AssertionError("No error should have been raised, "
                                      "but one was with the following "
                                      "message:\n\n%s" % str(e))
 
-    def test_in_bounds_fuzz(self):
+    def test_in_bounds_fuzz(self, closed):
         # Don't use fixed seed
         random.brng.seed()
 
         for dt in self.itype[1:]:
             for ubnd in [4, 8, 16]:
-                vals = self.rfunc(2, ubnd, size=2 ** 16, dtype=dt)
+                vals = self.rfunc(2, ubnd - closed, size=2 ** 16, closed=closed, dtype=dt)
                 assert_(vals.max() < ubnd)
                 assert_(vals.min() >= 2)
 
-        vals = self.rfunc(0, 2, size=2 ** 16, dtype=bool)
-
+        vals = self.rfunc(0, 2 - closed, size=2 ** 16, closed=closed, dtype=bool)
         assert_(vals.max() < 2)
         assert_(vals.min() >= 0)
 
-    def test_scalar_array_equiv(self):
+    def test_scalar_array_equiv(self, closed):
         for dt in self.itype:
             lbnd = 0 if dt is bool else np.iinfo(dt).min
             ubnd = 2 if dt is bool else np.iinfo(dt).max + 1
+            ubnd = ubnd - 1 if closed else ubnd
 
             size = 1000
             random.brng.seed(1234)
-            scalar = self.rfunc(lbnd, ubnd, size=size, dtype=dt)
+            scalar = self.rfunc(lbnd, ubnd, size=size, closed=closed, dtype=dt)
 
             random.brng.seed(1234)
-            scalar_array = self.rfunc([lbnd], [ubnd], size=size, dtype=dt)
+            scalar_array = self.rfunc([lbnd], [ubnd], size=size, closed=closed, dtype=dt)
 
             random.brng.seed(1234)
             array = self.rfunc([lbnd] * size, [ubnd] *
-                               size, size=size, dtype=dt)
+                               size, size=size, closed=closed, dtype=dt)
             assert_array_equal(scalar, scalar_array)
             assert_array_equal(scalar, array)
 
-    def test_repeatability(self):
+    def test_repeatability(self, closed):
         import hashlib
         # We use a md5 hash of generated sequences of 1000 samples
         # in the range [0, 6) for all but bool, where the range
@@ -302,68 +315,69 @@ class TestRandint(object):
 
             # view as little endian for hash
             if sys.byteorder == 'little':
-                val = self.rfunc(0, 6, size=1000, dtype=dt)
+                val = self.rfunc(0, 6 - closed, size=1000, closed=closed, dtype=dt)
             else:
-                val = self.rfunc(0, 6, size=1000, dtype=dt).byteswap()
+                val = self.rfunc(0, 6 - closed, size=1000, closed=closed, dtype=dt).byteswap()
 
             res = hashlib.md5(val.view(np.int8)).hexdigest()
             assert_(tgt[np.dtype(dt).name] == res)
 
         # bools do not depend on endianness
         random.brng.seed(1234)
-        val = self.rfunc(0, 2, size=1000, dtype=bool).view(np.int8)
+        val = self.rfunc(0, 2 - closed, size=1000, closed=closed, dtype=bool).view(np.int8)
         res = hashlib.md5(val).hexdigest()
         assert_(tgt[np.dtype(bool).name] == res)
 
-    def test_repeatability_broadcasting(self):
-
+    def test_repeatability_broadcasting(self, closed):
         for dt in self.itype:
             lbnd = 0 if dt in (np.bool, bool, np.bool_) else np.iinfo(dt).min
             ubnd = 2 if dt in (
                 np.bool, bool, np.bool_) else np.iinfo(dt).max + 1
+            ubnd = ubnd - 1 if closed else ubnd
 
             # view as little endian for hash
             random.brng.seed(1234)
-            val = self.rfunc(lbnd, ubnd, size=1000, dtype=dt)
+            val = self.rfunc(lbnd, ubnd, size=1000, closed=closed, dtype=dt)
 
             random.brng.seed(1234)
-            val_bc = self.rfunc([lbnd] * 1000, ubnd, dtype=dt)
+            val_bc = self.rfunc([lbnd] * 1000, ubnd, closed=closed, dtype=dt)
 
             assert_array_equal(val, val_bc)
 
             random.brng.seed(1234)
-            val_bc = self.rfunc([lbnd] * 1000, [ubnd] * 1000, dtype=dt)
+            val_bc = self.rfunc([lbnd] * 1000, [ubnd] * 1000, closed=closed, dtype=dt)
 
             assert_array_equal(val, val_bc)
 
-    def test_int64_uint64_broadcast_exceptions(self):
+    def test_int64_uint64_broadcast_exceptions(self, closed):
         configs = {np.uint64: ((0, 2**65), (-1, 2**62), (10, 9), (0, 0)),
                    np.int64: ((0, 2**64), (-(2**64), 2**62), (10, 9), (0, 0),
                               (-2**63-1, -2**63-1))}
         for dtype in configs:
             for config in configs[dtype]:
                 low, high = config
+                high = high - closed
                 low_a = np.array([[low]*10])
                 high_a = np.array([high] * 10)
                 assert_raises(ValueError, random.randint, low, high,
-                              dtype=dtype)
+                              closed=closed, dtype=dtype)
                 assert_raises(ValueError, random.randint, low_a, high,
-                              dtype=dtype)
+                              closed=closed, dtype=dtype)
                 assert_raises(ValueError, random.randint, low, high_a,
-                              dtype=dtype)
+                              closed=closed, dtype=dtype)
                 assert_raises(ValueError, random.randint, low_a, high_a,
-                              dtype=dtype)
+                              closed=closed, dtype=dtype)
 
                 low_o = np.array([[low]*10], dtype=np.object)
                 high_o = np.array([high] * 10, dtype=np.object)
                 assert_raises(ValueError, random.randint, low_o, high,
-                              dtype=dtype)
+                              closed=closed, dtype=dtype)
                 assert_raises(ValueError, random.randint, low, high_o,
-                              dtype=dtype)
+                              closed=closed, dtype=dtype)
                 assert_raises(ValueError, random.randint, low_o, high_o,
-                              dtype=dtype)
+                              closed=closed, dtype=dtype)
 
-    def test_int64_uint64_corner_case(self):
+    def test_int64_uint64_corner_case(self, closed):
         # When stored in Numpy arrays, `lbnd` is casted
         # as np.int64, and `ubnd` is casted as np.uint64.
         # Checking whether `lbnd` >= `ubnd` used to be
@@ -379,51 +393,54 @@ class TestRandint(object):
         dt = np.int64
         tgt = np.iinfo(np.int64).max
         lbnd = np.int64(np.iinfo(np.int64).max)
-        ubnd = np.uint64(np.iinfo(np.int64).max + 1)
+        ubnd = np.uint64(np.iinfo(np.int64).max + 1 - closed)
 
         # None of these function calls should
         # generate a ValueError now.
-        actual = random.randint(lbnd, ubnd, dtype=dt)
+        actual = random.randint(lbnd, ubnd, closed=closed, dtype=dt)
         assert_equal(actual, tgt)
 
-    def test_respect_dtype_singleton(self):
+    def test_respect_dtype_singleton(self, closed):
         # See gh-7203
         for dt in self.itype:
             lbnd = 0 if dt is bool else np.iinfo(dt).min
             ubnd = 2 if dt is bool else np.iinfo(dt).max + 1
+            ubnd = ubnd - 1 if closed else ubnd
             dt = np.bool_ if dt is bool else dt
 
-            sample = self.rfunc(lbnd, ubnd, dtype=dt)
+            sample = self.rfunc(lbnd, ubnd, closed=closed, dtype=dt)
             assert_equal(sample.dtype, dt)
 
         for dt in (bool, int, np.long):
             lbnd = 0 if dt is bool else np.iinfo(dt).min
             ubnd = 2 if dt is bool else np.iinfo(dt).max + 1
+            ubnd = ubnd - 1 if closed else ubnd
 
             # gh-7284: Ensure that we get Python data types
-            sample = self.rfunc(lbnd, ubnd, dtype=dt)
+            sample = self.rfunc(lbnd, ubnd, closed=closed, dtype=dt)
             assert not hasattr(sample, 'dtype')
             assert_equal(type(sample), dt)
 
-    def test_respect_dtype_array(self):
+    def test_respect_dtype_array(self, closed):
         # See gh-7203
         for dt in self.itype:
             lbnd = 0 if dt is bool else np.iinfo(dt).min
             ubnd = 2 if dt is bool else np.iinfo(dt).max + 1
+            ubnd = ubnd - 1 if closed else ubnd
             dt = np.bool_ if dt is bool else dt
 
-            sample = self.rfunc([lbnd], [ubnd], dtype=dt)
+            sample = self.rfunc([lbnd], [ubnd], closed=closed, dtype=dt)
             assert_equal(sample.dtype, dt)
-            sample = self.rfunc([lbnd] * 2, [ubnd] * 2, dtype=dt)
+            sample = self.rfunc([lbnd] * 2, [ubnd] * 2, closed=closed, dtype=dt)
             assert_equal(sample.dtype, dt)
 
-    def test_zero_size(self):
+    def test_zero_size(self, closed):
         # See gh-7203
         for dt in self.itype:
-            sample = self.rfunc(0, 0, (3, 0, 4), dtype=dt)
+            sample = self.rfunc(0, 0, (3, 0, 4), closed=closed, dtype=dt)
             assert sample.shape == (3, 0, 4)
             assert sample.dtype == dt
-            assert self.rfunc(0, -10, 0, dtype=dt).shape == (0,)
+            assert self.rfunc(0, -10, 0, closed=closed, dtype=dt).shape == (0,)
 
 
 class TestRandomDist(object):


### PR DESCRIPTION
Add closed interval sampling to randint to simplify using int64/uint64
when the range may be full