### PR TITLE
MAINT: Rename jump to jumped and deprecate

### DIFF
--- a/doc/source/bit_generators/dsfmt.rst
+++ b/doc/source/bit_generators/dsfmt.rst
@@ -22,6 +22,7 @@ Parallel generation
 .. autosummary::
    :toctree: generated/
 
+   ~DSFMT.jumped
    ~DSFMT.jump
 
 Random Generator

--- a/doc/source/bit_generators/mt19937.rst
+++ b/doc/source/bit_generators/mt19937.rst
@@ -22,6 +22,7 @@ Parallel generation
    :toctree: generated/
 
    ~MT19937.jump
+   ~MT19937.jumped
 
 Random Generator
 ================

--- a/doc/source/bit_generators/pcg32.rst
+++ b/doc/source/bit_generators/pcg32.rst
@@ -23,6 +23,7 @@ Parallel generation
 
    ~PCG32.advance
    ~PCG32.jump
+   ~PCG32.jumped
 
 Random Generator
 ================

--- a/doc/source/bit_generators/pcg64.rst
+++ b/doc/source/bit_generators/pcg64.rst
@@ -23,6 +23,7 @@ Parallel generation
 
    ~PCG64.advance
    ~PCG64.jump
+   ~PCG64.jumped
 
 Random Generator
 ================

--- a/doc/source/bit_generators/philox.rst
+++ b/doc/source/bit_generators/philox.rst
@@ -23,6 +23,7 @@ Parallel generation
 
    ~Philox.advance
    ~Philox.jump
+   ~Philox.jumped
 
 Random Generator
 ================

--- a/doc/source/bit_generators/threefry.rst
+++ b/doc/source/bit_generators/threefry.rst
@@ -23,6 +23,7 @@ Parallel generation
 
    ~ThreeFry.advance
    ~ThreeFry.jump
+   ~ThreeFry.jumped
 
 Random Generator
 ================

--- a/doc/source/bit_generators/threefry32.rst
+++ b/doc/source/bit_generators/threefry32.rst
@@ -23,6 +23,7 @@ Parallel generation
 
    ~ThreeFry32.advance
    ~ThreeFry32.jump
+   ~ThreeFry32.jumped
 
 Random Generator
 ================

--- a/doc/source/bit_generators/xoroshiro128.rst
+++ b/doc/source/bit_generators/xoroshiro128.rst
@@ -22,6 +22,7 @@ Parallel generation
    :toctree: generated/
 
    ~Xoroshiro128.jump
+   ~Xoroshiro128.jumped
 
 Random Generator
 ================

--- a/doc/source/bit_generators/xorshift1024.rst
+++ b/doc/source/bit_generators/xorshift1024.rst
@@ -22,6 +22,7 @@ Parallel generation
    :toctree: generated/
 
    ~Xorshift1024.jump
+   ~Xorshift1024.jumped
 
 Random Generator
 ================

--- a/doc/source/bit_generators/xoshiro256starstar.rst
+++ b/doc/source/bit_generators/xoshiro256starstar.rst
@@ -22,6 +22,7 @@ Parallel generation
    :toctree: generated/
 
    ~Xoshiro256StarStar.jump
+   ~Xoshiro256StarStar.jumped
 
 Random Generator
 ================

--- a/doc/source/bit_generators/xoshiro512starstar.rst
+++ b/doc/source/bit_generators/xoshiro512starstar.rst
@@ -22,6 +22,7 @@ Parallel generation
    :toctree: generated/
 
    ~Xoshiro512StarStar.jump
+   ~Xoshiro512StarStar.jumped
 
 Random Generator
 ================

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -161,7 +161,7 @@ generators, 'in addition' to the standard PRNG in NumPy.  The included PRNGs are
 
 * MT19937 - The standard NumPy generator.  Produces identical results to NumPy
   using the same seed/state. Adds a jump function that advances the generator
-  as-if 2**128 draws have been made (:meth:`~randomgen.mt19937.MT19937.jump`).
+  as-if 2**128 draws have been made (:meth:`~randomgen.mt19937.MT19937.jumped`).
   See `NumPy's documentation`_.
 * dSFMT - SSE2 enabled versions of the MT19937 generator.  Theoretically
   the same, but with a different state and so it is not possible to produce a
@@ -170,19 +170,19 @@ generators, 'in addition' to the standard PRNG in NumPy.  The included PRNGs are
 * XoroShiro128+ - Improved version of XorShift128+ with better performance
   and statistical quality. Like the XorShift generators, it can be jumped
   to produce multiple streams in parallel applications. See
-  :meth:`~randomgen.xoroshiro128.Xoroshiro128.jump` for details.
+  :meth:`~randomgen.xoroshiro128.Xoroshiro128.jumped` for details.
   More information about this PRNG is available at the
   `xorshift, xoroshiro and xoshiro authors' page`_.
 * XorShift1024*φ - Fast fast generator based on the XSadd
   generator. Supports ``jump`` and so can be used in
   parallel applications. See the documentation for
-  :meth:`~randomgen.xorshift1024.Xorshift1024.jump` for details. More information
+  :meth:`~randomgen.xorshift1024.Xorshift1024.jumped` for details. More information
   about these PRNGs is available at the
   `xorshift, xoroshiro and xoshiro authors' page`_.
 * Xorshiro256** and Xorshiro512** - The most recently introduced XOR,
   shift, and rotate generator. Supports ``jump`` and so can be used in
   parallel applications. See the documentation for
-  :meth:`~randomgen.xoshiro256starstar.Xoshirt256StarStar.jump` for details. More
+  :meth:`~randomgen.xoshiro256starstar.Xoshirt256StarStar.jumped` for details. More
   information about these PRNGs is available at the
   `xorshift, xoroshiro and xoshiro authors' page`_.
 * PCG-64 - Fast generator that support many parallel streams and

--- a/doc/source/multithreading.rst
+++ b/doc/source/multithreading.rst
@@ -10,7 +10,7 @@ these requirements.
 This example makes use of Python 3 :mod:`concurrent.futures` to fill an array
 using multiple threads.  Threads are long-lived so that repeated calls do not
 require any additional overheads from thread creation. The underlying PRNG is
-xorshift2014 which is fast, has a long period and supports using ``jump`` to
+xorshift2014 which is fast, has a long period and supports using ``jumped`` to
 advance the state. The random numbers generated are reproducible in the sense
 that the same seed will produce the same outputs.
 
@@ -28,14 +28,13 @@ that the same seed will produce the same outputs.
                 threads = multiprocessing.cpu_count()
             self.threads = threads
     
-            self._random_generators = []
+            self._random_generators = [rg]
+            last_rg = rg
             for _ in range(0, threads-1):
-                _rg = Xorshift1024()
-                _rg.state = rg.state
-                self._random_generators.append(_rg.generator)
-                rg.jump()
-            self._random_generators.append(rg.generator)
-    
+                new_rg = last_rg.jumped()
+                self._random_generators.append()
+                last_rg = new_rg
+
             self.n = n
             self.executor = concurrent.futures.ThreadPoolExecutor(threads)
             self.values = np.empty(n)

--- a/doc/source/parallel.rst
+++ b/doc/source/parallel.rst
@@ -47,16 +47,16 @@ to produce independent streams.
 Jump/Advance the PRNG state
 ---------------------------
 
-Jump
-****
+Jumped
+******
 
-``jump`` advances the state of the PRNG *as-if* a large number of random
-numbers have been drawn.  The specific number of draws varies by PRNG, and
-ranges from :math:`2^{64}` to :math:`2^{512}`.  Additionally, the *as-if*
-draws also depend on the size of the default random number produced by the
-specific PRNG.  The PRNGs that support ``jump``, along with the period of
-the PRNG, the size of the jump and the bits in the default unsigned random
-are listed below.
+``jumped`` advances the state of the PRNG *as-if* a large number of random
+numbers have been drawn, and returns a new instance with this state.  The
+specific number of draws varies by PRNG, and ranges from :math:`2^{64}` to
+:math:`2^{512}`.  Additionally, the *as-if* draws also depend on the size of
+the default random number produced by the specific PRNG.  The PRNGs that
+support ``jumped``, along with the period of the PRNG, the size of the jump
+and the bits in the default unsigned random are listed below.
 
 +-----------------+-------------------------+-------------------------+-------------------------+
 | PRNG            | Period                  |  Jump Size              | Bits                    |
@@ -76,7 +76,7 @@ are listed below.
 | Xorshift1024    | :math:`2^{1024}`        | :math:`2^{512}`         | 64                      |
 +-----------------+-------------------------+-------------------------+-------------------------+
 
-``jump`` can be used to produce long blocks which should be long enough to not
+``jumped`` can be used to produce long blocks which should be long enough to not
 overlap.
 
 .. code-block:: python
@@ -88,10 +88,10 @@ overlap.
   # 64-bit number as a seed
   seed = entropy[0] * 2**32 + entropy[1]
   blocked_rng = []
+  last_rng = rng = Xorshift1024(seed)
   for i in range(10):
-      rng = Xorshift1024(seed)
-      rng.jump(i)
-      blocked_rng.append(rng)
+      blocked_rng.append(last_rng)
+      last_rng = last_rng.jumped()
 
 
 Advance

--- a/randomgen/dsfmt.pyx
+++ b/randomgen/dsfmt.pyx
@@ -1,6 +1,7 @@
 import operator
 from libc.stdlib cimport malloc, free
-from cpython.pycapsule cimport PyCapsule_New
+from libc.string cimport memcpy
+from cpython.pycapsule cimport PyCapsule_New, PyCapsule_GetPointer
 
 try:
     from threading import Lock
@@ -283,12 +284,47 @@ cdef class DSFMT:
         self : DSFMT
             PRNG jumped iter times
         """
+        import warnings
+        warnings.warn('jump (in-place) has been deprecated in favor of jumped'
+                      ', which returns a new instance', DeprecationWarning)
+
         cdef np.npy_intp i
         for i in range(iter):
             dsfmt_jump(self.rng_state)
         # Clear the buffer
         self._reset_state_variables()
         return self
+
+    def jumped(self, np.npy_intp iter=1):
+        """
+        jumped(iter=1)
+
+        Returns a new bit generator with the state jumped
+
+        The state of the returned big generator is jumped as-if
+        2**(128 * iter) random numbers have been generated.
+
+        Parameters
+        ----------
+        iter : integer, positive
+            Number of times to jump the state of the bit generator returned
+
+        Returns
+        -------
+        bit_generator : Xoroshiro128
+            New instance of generator jumped iter times
+        """
+        cdef np.npy_intp i
+        cdef bitgen_t *new_bitgen
+        cdef dsfmt_state *new_rng_state
+        bit_generator = self.__class__()
+        cdef const char *name = "BitGenerator"
+        new_bitgen = <bitgen_t *>PyCapsule_GetPointer(bit_generator.capsule,
+                                                      name)
+        new_rng_state = <dsfmt_state *>new_bitgen.state
+        for i in range(iter):
+            dsfmt_jump(new_rng_state)
+        return bit_generator
 
     @property
     def state(self):

--- a/randomgen/philox.pyx
+++ b/randomgen/philox.pyx
@@ -1,5 +1,5 @@
 from libc.stdlib cimport malloc, free
-from cpython.pycapsule cimport PyCapsule_New
+from cpython.pycapsule cimport PyCapsule_New, PyCapsule_GetPointer
 
 try:
     from threading import Lock
@@ -367,7 +367,42 @@ cdef class Philox:
         Jumping the rng state resets any pre-computed random numbers. This is
         required to ensure exact reproducibility.
         """
+        import warnings
+        warnings.warn('jump (in-place) has been deprecated in favor of jumped'
+                      ', which returns a new instance', DeprecationWarning)
+
         return self.advance(iter * 2 ** 128)
+
+    def jumped(self, np.npy_intp iter=1):
+        """
+        jumped(iter=1)
+
+        Returns a new bit generator with the state jumped
+
+        The state of the returned big generator is jumped as-if
+        2**(128 * iter) random numbers have been generated.
+
+        Parameters
+        ----------
+        iter : integer, positive
+            Number of times to jump the state of the bit generator returned
+
+        Returns
+        -------
+        bit_generator : Xoroshiro128
+            New instance of generator jumped iter times
+        """
+        cdef bitgen_t *new_bitgen
+        cdef np.ndarray delta_a
+        bit_generator = self.__class__()
+        cdef const char *name = "BitGenerator"
+        new_bitgen = <bitgen_t *>PyCapsule_GetPointer(bit_generator.capsule,
+                                                      name)
+
+        delta_a = int_to_array(iter * 2**128, 'step', 256, 64)
+        philox_advance(<uint64_t *>delta_a.data, <philox_state *>new_bitgen.state)
+
+        return bit_generator
 
     def advance(self, delta):
         """

--- a/randomgen/tests/test_smoke.py
+++ b/randomgen/tests/test_smoke.py
@@ -143,14 +143,27 @@ class RNG(object):
     def test_jump(self):
         state = self.rg.bit_generator.state
         if hasattr(self.rg.bit_generator, 'jump'):
-            self.rg.bit_generator.jump()
+            with pytest.deprecated_call():
+                self.rg.bit_generator.jump()
             jumped_state = self.rg.bit_generator.state
             assert_(not comp_state(state, jumped_state))
             self.rg.random(2 * 3 * 5 * 7 * 11 * 13 * 17)
             self.rg.bit_generator.state = state
-            self.rg.bit_generator.jump()
+            with pytest.deprecated_call():
+                self.rg.bit_generator.jump()
             rejumped_state = self.rg.bit_generator.state
             assert_(comp_state(jumped_state, rejumped_state))
+        else:
+            bit_gen_name = self.rg.bit_generator.__class__.__name__
+            pytest.skip('Jump is not supported by {0}'.format(bit_gen_name))
+
+    def test_jumped(self):
+        state = self.rg.bit_generator.state
+        if hasattr(self.rg.bit_generator, 'jumped'):
+            new_bit_gen = self.rg.bit_generator.jumped()
+            assert isinstance(new_bit_gen, self.rg.bit_generator.__class__)
+            assert_(comp_state(state, self.rg.bit_generator.state))
+            Generator(new_bit_gen).random(1000000)
         else:
             bit_gen_name = self.rg.bit_generator.__class__.__name__
             pytest.skip('Jump is not supported by {0}'.format(bit_gen_name))

--- a/randomgen/xorshift1024.pyx
+++ b/randomgen/xorshift1024.pyx
@@ -4,7 +4,7 @@ except ImportError:
     from dummy_threading import Lock
 
 from libc.stdlib cimport malloc, free
-from cpython.pycapsule cimport PyCapsule_New
+from cpython.pycapsule cimport PyCapsule_New, PyCapsule_GetPointer
 
 import numpy as np
 cimport numpy as np
@@ -255,14 +255,50 @@ cdef class Xorshift1024:
 
         Notes
         -----
-        Jumping the rng state resets any pre-computed random numbers. This is required
-        to ensure exact reproducibility.
+        Jumping the rng state resets any pre-computed random numbers. This is
+        required to ensure exact reproducibility.
         """
+        import warnings
+        warnings.warn('jump (in-place) has been deprecated in favor of jumped'
+                      ', which returns a new instance', DeprecationWarning)
+
         cdef np.npy_intp i
         for i in range(iter):
             xorshift1024_jump(self.rng_state)
         self._reset_state_variables()
         return self
+
+    def jumped(self, np.npy_intp iter=1):
+        """
+        jumped(iter=1)
+
+        Returns a new bit generator with the state jumped
+
+        The state of the returned big generator is jumped as-if
+        2**(512 * iter) random numbers have been generated.
+
+        Parameters
+        ----------
+        iter : integer, positive
+            Number of times to jump the state of the bit generator returned
+
+        Returns
+        -------
+        bit_generator : Xoroshiro128
+            New instance of generator jumped iter times
+        """
+        cdef np.npy_intp i
+        cdef bitgen_t *new_bitgen
+        bit_generator = self.__class__()
+        cdef const char *name = "BitGenerator"
+        new_bitgen = <bitgen_t *>PyCapsule_GetPointer(bit_generator.capsule,
+                                                      name)
+        for i in range(iter):
+            xorshift1024_jump(<xorshift1024_state *>new_bitgen.state)
+
+        return bit_generator
+
+
 
     @property
     def state(self):

--- a/randomgen/xoshiro512starstar.pyx
+++ b/randomgen/xoshiro512starstar.pyx
@@ -4,7 +4,7 @@ except ImportError:
     from dummy_threading import Lock
 
 from libc.stdlib cimport malloc, free
-from cpython.pycapsule cimport PyCapsule_New
+from cpython.pycapsule cimport PyCapsule_New, PyCapsule_GetPointer
 
 import numpy as np
 cimport numpy as np
@@ -247,14 +247,48 @@ cdef class Xoshiro512StarStar:
 
         Notes
         -----
-        Jumping the rng state resets any pre-computed random numbers. This is required
-        to ensure exact reproducibility.
+        Jumping the rng state resets any pre-computed random numbers. This is
+        required to ensure exact reproducibility.
         """
+        import warnings
+        warnings.warn('jump (in-place) has been deprecated in favor of jumped'
+                      ', which returns a new instance', DeprecationWarning)
+
         cdef np.npy_intp i
         for i in range(iter):
             xoshiro512starstar_jump(self.rng_state)
         self._reset_state_variables()
         return self
+
+    def jumped(self, np.npy_intp iter=1):
+        """
+        jumped(iter=1)
+
+        Returns a new bit generator with the state jumped
+
+        The state of the returned big generator is jumped as-if
+        2**(256 * iter) random numbers have been generated.
+
+        Parameters
+        ----------
+        iter : integer, positive
+            Number of times to jump the state of the bit generator returned
+
+        Returns
+        -------
+        bit_generator : Xoroshiro128
+            New instance of generator jumped iter times
+        """
+        cdef np.npy_intp i
+        cdef bitgen_t *new_bitgen
+        bit_generator = self.__class__()
+        cdef const char *name = "BitGenerator"
+        new_bitgen = <bitgen_t *>PyCapsule_GetPointer(bit_generator.capsule,
+                                                      name)
+        for i in range(iter):
+            xoshiro512starstar_jump(<xoshiro512starstar_state *>new_bitgen.state)
+
+        return bit_generator
 
     @property
     def state(self):


### PR DESCRIPTION
Deprecate jump and move to new method jumped
jumped returns a new instance