### PR TITLE
BUG: Ensure 32 bit value is reset after seed

### DIFF
--- a/randomgen/mt64.pxd
+++ b/randomgen/mt64.pxd
@@ -19,3 +19,4 @@ cdef extern from "src/mt64/mt64.h":
 cdef class MT64(BitGenerator):
 
     cdef mt64_state_t rng_state
+    cdef _reset_state_variables(self)

--- a/randomgen/mt64.pyx
+++ b/randomgen/mt64.pyx
@@ -79,6 +79,8 @@ cdef class MT64(BitGenerator):
         623-dimensionally equidistributed uniform pseudo-random number
         generator". ACM Transactions on Modeling and Computer Simulation.
         8 (1): 3–30.
+    .. [2] Nishimura, T. "Tables of 64-bit Mersenne Twisters" ACM Transactions
+        on Modeling and Computer Simulation 10. (2000) 348-357.
     """
     def __init__(self, seed=None):
         BitGenerator.__init__(self)
@@ -89,6 +91,10 @@ cdef class MT64(BitGenerator):
         self._bitgen.next_uint32 = &mt64_uint32
         self._bitgen.next_double = &mt64_double
         self._bitgen.next_raw = &mt64_raw
+
+    cdef _reset_state_variables(self):
+        self.rng_state.has_uint32 = 0
+        self.rng_state.uinteger = 0
 
     @classmethod
     def from_seed_seq(cls, entropy=None):
@@ -174,6 +180,8 @@ cdef class MT64(BitGenerator):
             mt64_init_by_array(&self.rng_state,
                                <uint64_t*>np.PyArray_DATA(obj),
                                np.PyArray_DIM(obj, 0))
+
+        self._reset_state_variables()
 
     @property
     def state(self):

--- a/randomgen/tests/test_direct.py
+++ b/randomgen/tests/test_direct.py
@@ -364,6 +364,17 @@ class Base(object):
         alt_state = bit_generator.__getstate__()
         assert_state_equal(state, alt_state)
 
+    def test_uinteger_reset_seed(self):
+        bg = self.bit_generator()
+        g = Generator(bg)
+        g.integers(0, 2 ** 32, dtype=np.uint32)
+        if 'has_uint32' not in bg.state or bg.state['has_uint32'] == 0:
+            name = bg.__class__.__name__
+            pytest.skip('bit generator does not cache 32-bit value '
+                        '({0})'.format(name))
+        bg.seed()
+        assert bg.state['has_uint32'] == 0
+
     def test_uinteger_reset_jump(self):
         bg = self.bit_generator()
         if not hasattr(bg, 'jumped'):


### PR DESCRIPTION
Reset value after seed on MT64
Add test for all generators