### PR TITLE
BUG: Fix edge value in randint

### DIFF
--- a/doc/source/change-log.rst
+++ b/doc/source/change-log.rst
@@ -3,8 +3,18 @@
 Change Log
 ----------
 
+
 v1.17.0
 =======
+- Fixed a bug that affected both :class:`~randomgen.generator.Generator.randint`
+  in :class:`~randomgen.generator.Generator` and :meth:`~randomgen.mtrand.RandomState.randint`
+  in  :class:`~randomgen.mtrand.RandomState` when ``high=2**32``.  This value is inbounds for
+  a 32-bit unsigned closed interval generator, and so  should have been redirected to
+  a 32-bit generator. It  was erroneously sent to the 64-bit path. The random values produced
+  are fully random but inefficient. This fix breaks the stream in :class:`~randomgen.generator.Generator
+  is the value for ``high`` is used. The fix restores :class:`~randomgen.mtrand.RandomState` to
+  NumPy 1.16 compatibility.
+  only affects the output if ``dtype`` is ``'int64'``
 - This release brings many breaking changes.  Most of these have been
   implemented using ``DeprecationWarnings``. This has been done to
   bring ``randomgen`` in-line with the API changes of the version

--- a/randomgen/src/distributions/distributions.c
+++ b/randomgen/src/distributions/distributions.c
@@ -1461,7 +1461,7 @@ uint64_t random_bounded_uint64(bitgen_t *bitgen_state, uint64_t off,
                                uint64_t rng, uint64_t mask, bool use_masked) {
   if (rng == 0) {
     return off;
-  } else if (rng < 0xFFFFFFFFUL) {
+  } else if (rng <= 0xFFFFFFFFUL) {
     /* Call 32-bit generator if range in 32-bit. */
     if (use_masked) {
       return off + buffered_bounded_masked_uint32(bitgen_state, (uint32_t)rng,

--- a/randomgen/src/legacy/legacy-distributions.c
+++ b/randomgen/src/legacy/legacy-distributions.c
@@ -220,12 +220,11 @@ void legacy_random_bounded_uint64_fill(aug_bitgen_t *aug_state, uint64_t off,
                                        uint64_t rng, npy_intp cnt,
                                        uint64_t *out) {
   npy_intp i;
-
   if (rng == 0) {
     for (i = 0; i < cnt; i++) {
       out[i] = off;
     }
-  } else if (rng < 0xFFFFFFFFUL) {
+  } else if (rng <= 0xFFFFFFFFUL) {
     uint32_t buf = 0;
     int bcnt = 0;
 
@@ -244,7 +243,6 @@ void legacy_random_bounded_uint64_fill(aug_bitgen_t *aug_state, uint64_t off,
       out[i] = off + next_uint64(aug_state->bit_generator);
     }
   } else {
-
     /* Smallest bit mask >= max */
     uint64_t mask = gen_mask(rng);
 

--- a/randomgen/tests/test_randomstate_regression.py
+++ b/randomgen/tests/test_randomstate_regression.py
@@ -7,6 +7,7 @@ import pytest
 
 import randomgen.mtrand as random
 
+HAS_32BIT_CLONG = np.iinfo('l').max < 2**32
 
 class TestRegression(object):
 
@@ -160,3 +161,13 @@ class TestRegression(object):
         other_byteord_dt = '<i4' if sys.byteorder == 'big' else '>i4'
         with pytest.warns(FutureWarning):
             random.randint(0, 200, size=10, dtype=other_byteord_dt)
+
+    @pytest.mark.skipif(HAS_32BIT_CLONG,
+                        reason='Cannot test with 32-bit C long')
+    def test_randint_117(self):
+        random.seed(0)
+        expected = np.array([2357136044, 2546248239, 3071714933, 3626093760,
+                             2588848963, 3684848379, 2340255427, 3638918503,
+                             1819583497, 2678185683], dtype='int64')
+        actual = random.randint(2**32, size=10)
+        assert_array_equal(actual, expected)


### PR DESCRIPTION
Fix bug in randint which did not route 2**32 high values to the
32-bit generator. This fix breaks the stream in Generator if
this function call was made.