### PR TITLE
Non-uniform random floats (mt19937.h)

### DIFF
--- a/randomgen/src/mt19937/mt19937.h
+++ b/randomgen/src/mt19937/mt19937.h
@@ -52,7 +52,7 @@ static INLINE uint32_t mt19937_next32(mt19937_state_t *state) {
 
 static INLINE double mt19937_next_double(mt19937_state_t *state) {
   int32_t a = mt19937_next(state) >> 5, b = mt19937_next(state) >> 6;
-  return (a * 67108864.0 + b) / 9007199254740992.0;
+  return ((((uint64_t)(a) << 26) | b) | 1) / 9007199254740992.0;  
 }
 
 void mt19937_jump(mt19937_state_t *state);


### PR DESCRIPTION
The current implementation produces an output that has some bias in the lower bits of mantissa (more 0's than 1's). That's because we try to fit 2^53 pigeons into 2^52 holes, so rounding to even is unavoidable. My solution is to generate just 2^52 pigeons using the expression (randbits_53 | 1) to generate 2^52 odd numbers only in the range [1, 2^53-1] , with zero cannot be generated. but, the distribution of mantissa bits becomes more uniform.