### PR TITLE
Non-uniform random floats (jsf.h)

### DIFF
--- a/randomgen/src/jsf/jsf.h
+++ b/randomgen/src/jsf/jsf.h
@@ -103,7 +103,7 @@ static INLINE uint32_t jsf64_next32(jsf_state_t *state) {
   return (uint32_t)(next & 0xffffffff);
 }
 static INLINE double jsf64_next_double(jsf_state_t *state) {
-    return (next64(state) >> 11) * (1.0 / 9007199254740992.0);
+    return ((next64(state) >> 11) | 1) * (1.0 / 9007199254740992.0);  
 }
 static INLINE uint64_t jsf32_next64(jsf_state_t *state) {
     return (uint64_t)next32(state) << 32 | next32(state);
@@ -113,7 +113,7 @@ static INLINE uint32_t jsf32_next32(jsf_state_t *state) {
 }
 static INLINE double jsf32_next_double(jsf_state_t *state) {
   int32_t a = next32(state) >> 5, b = next32(state) >> 6;
-  return (a * 67108864.0 + b) / 9007199254740992.0;
+  return ((((uint64_t)(a) << 26) | b) | 1) / 9007199254740992.0;    
 }
 
 void jsf64_seed(jsf_state_t *state, uint64_t *seed, int size);


### PR DESCRIPTION
The current implementation produces an output that has some bias in the lower bits of mantissa (more 0's than 1's). That's because we try to fit 2^53 pigeons into 2^52 holes, so rounding to even is unavoidable. My solution is to generate just 2^52 pigeons using the expression (randbits_53 | 1) to generate 2^52 odd numbers only in the range [1, 2^53-1] , with zero cannot be generated. but, the distribution of mantissa bits becomes more uniform.