### PR TITLE
Add py.typed marker

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -352,7 +352,7 @@ setup(
     packages=find_packages(),
     package_dir={"randomgen": "./randomgen"},
     package_data={
-        "": ["*.h", "*.pxi", "*.pyx", "*.pxd", "*.in"],
+        "": ["*.h", "*.pxi", "*.pyx", "*.pxd", "*.in", "py.typed"],
         "randomgen.tests.data": ["*.csv"],
     },
     include_package_data=True,


### PR DESCRIPTION
Resolves mypy import error for type checking when randomgen is used within other projects.

```console
Skipping analyzing "randomgen": module is installed, but missing library stubs or py.typed marker  [import]
```